### PR TITLE
Refactor availability backend package for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "w2_fhr": "bin/w2_fhr.js"
   },
   "scripts": {
-    "build": "tsc; cd src/frontend; yarn build; cd ../..",
+    "build": "tsc; cd src/frontend; yarn build; cd ../GoogleSheets; go test ./...; cd ../..",
     "watch": "tsc -w",
     "test": "yarn test:Googlesheets",
     "test:Googlesheets": "cd src/Googlesheets; go test ./...",

--- a/src/GoogleSheets/packages/auth/get/main.go
+++ b/src/GoogleSheets/packages/auth/get/main.go
@@ -62,5 +62,5 @@ func getEmployeeId(email string, staffListInfo AuthConstants.STAFF_LIST_INFO) (s
 	}
 
 	log.Printf("[INFO] No employeeId found for %s", email)
-	return "", errors.New(SharedConstants.EMPLOYEE_NOT_FOUND_ERROR)
+	return "", SharedConstants.ErrEmployeeNotFound
 }

--- a/src/GoogleSheets/packages/availability/handlers/AvailabilitySheet.go
+++ b/src/GoogleSheets/packages/availability/handlers/AvailabilitySheet.go
@@ -3,6 +3,7 @@ package Availability
 import (
 	"GoogleSheets/packages/common/Constants/SharedConstants"
 	"GoogleSheets/packages/common/GoogleClient"
+	"errors"
 	"fmt"
 
 	"google.golang.org/api/sheets/v4"
@@ -19,9 +20,9 @@ const (
 	availabilityEmployeeIds   = availabilitySheetName + "!A2:A"
 	availabilityCells         = availabilitySheetName + "!E2:H"
 	availabilityUpdateOffset  = 2
-
-	UPDATE_AVAILABILITY_DISABLED_ERROR = "UPDATE_AVAILABILITY_DISABLED_ERROR"
 )
+
+var ErrNoUpdating = errors.New("UPDATE_AVAILABILITY_DISABLED_ERROR")
 
 type EmployeeAvailabilityDay struct {
 	IsAvailable bool   `json:"isAvailable"`

--- a/src/GoogleSheets/packages/availability/handlers/AvailabilitySheet.go
+++ b/src/GoogleSheets/packages/availability/handlers/AvailabilitySheet.go
@@ -3,7 +3,6 @@ package Availability
 import (
 	"GoogleSheets/packages/common/Constants/SharedConstants"
 	"GoogleSheets/packages/common/GoogleClient"
-	"errors"
 	"fmt"
 
 	"google.golang.org/api/sheets/v4"
@@ -44,45 +43,25 @@ type AllAvailability struct {
 	CanUpdate      bool
 }
 
-type availabilitySheet struct {
+type availabilitySheet interface {
+	Get() (*AllAvailability, error)
+	Update(int, *EmployeeAvailability) error
+}
+
+type sheet struct {
 	service *sheets.Service
 }
 
-func getAvailabilitySheet() (*availabilitySheet, error) {
+func getAvailabilitySheet() (availabilitySheet, error) {
 	service, err := GoogleClient.New()
 	if err != nil {
-		return &availabilitySheet{}, err
+		return &sheet{}, err
 	}
 
-	return &availabilitySheet{service: service}, nil
+	return &sheet{service: service}, nil
 }
 
-func (a *availabilitySheet) Get(employeeId string) (*EmployeeAvailability, error) {
-	all, err := a.getAll()
-	if err != nil {
-		return &EmployeeAvailability{}, err
-	}
-
-	r, err := findRowOfEmployee(all.EmployeeIds, employeeId)
-	if err != nil {
-		return &EmployeeAvailability{}, err
-	}
-
-	day1 := all.Availabilities[r][0] == "TRUE"
-	day2 := all.Availabilities[r][1] == "TRUE"
-	day3 := all.Availabilities[r][2] == "TRUE"
-	day4 := all.Availabilities[r][3] == "TRUE"
-
-	return &EmployeeAvailability{
-		Day1:      EmployeeAvailabilityDay{IsAvailable: day1, Date: all.Dates[0].(string)},
-		Day2:      EmployeeAvailabilityDay{IsAvailable: day2, Date: all.Dates[1].(string)},
-		Day3:      EmployeeAvailabilityDay{IsAvailable: day3, Date: all.Dates[2].(string)},
-		Day4:      EmployeeAvailabilityDay{IsAvailable: day4, Date: all.Dates[3].(string)},
-		CanUpdate: all.CanUpdate,
-	}, nil
-}
-
-func (a *availabilitySheet) getAll() (*AllAvailability, error) {
+func (a *sheet) Get() (*AllAvailability, error) {
 	r1, err := a.service.Spreadsheets.Values.
 		BatchGet(availabilitySheetId).
 		Ranges(
@@ -110,21 +89,7 @@ func (a *availabilitySheet) getAll() (*AllAvailability, error) {
 	}, nil
 }
 
-func (a *availabilitySheet) Update(employeeId string, newAvailability *EmployeeAvailability) error {
-	all, err := a.getAll()
-	if err != nil {
-		return err
-	}
-
-	if !all.CanUpdate {
-		return fmt.Errorf(UPDATE_AVAILABILITY_DISABLED_ERROR)
-	}
-
-	row, err := findRowOfEmployee(all.EmployeeIds, employeeId)
-	if err != nil {
-		return err
-	}
-
+func (a *sheet) Update(row int, newAvailability *EmployeeAvailability) error {
 	updateValueRange := &sheets.ValueRange{
 		Values: [][]interface{}{
 			{
@@ -139,7 +104,7 @@ func (a *availabilitySheet) Update(employeeId string, newAvailability *EmployeeA
 	r := row + availabilityUpdateOffset
 	updateRange := fmt.Sprintf("%s!%s%d:%s%d", availabilitySheetName, availabilityDay1Col, r, availabilityDay4Col, r)
 
-	_, err = a.service.Spreadsheets.Values.
+	_, err := a.service.Spreadsheets.Values.
 		Update(availabilitySheetId, updateRange, updateValueRange).
 		ValueInputOption("RAW").
 		Do()
@@ -156,5 +121,5 @@ func findRowOfEmployee(employeeIds [][]interface{}, employeeId string) (int, err
 			return i, nil
 		}
 	}
-	return 0, errors.New(SharedConstants.EMPLOYEE_NOT_FOUND_ERROR)
+	return 0, SharedConstants.ErrEmployeeNotFound
 }

--- a/src/GoogleSheets/packages/availability/handlers/GetAvailability.go
+++ b/src/GoogleSheets/packages/availability/handlers/GetAvailability.go
@@ -10,11 +10,32 @@ func Get(employeeId string) (*EmployeeAvailability, error) {
 		return &EmployeeAvailability{}, err
 	}
 
-	employeeAvailability, err := sheet.Get(employeeId)
+	return doGet(employeeId, sheet)
+}
+
+func doGet(employeeId string, sheet availabilitySheet) (*EmployeeAvailability, error) {
+	all, err := sheet.Get()
 	if err != nil {
 		return &EmployeeAvailability{}, err
 	}
 
-	log.Printf("[INFO] Found availability for %s: %v", employeeId, employeeAvailability)
-	return employeeAvailability, nil
+	r, err := findRowOfEmployee(all.EmployeeIds, employeeId)
+	if err != nil {
+		return &EmployeeAvailability{}, err
+	}
+
+	day1 := all.Availabilities[r][0] == "TRUE"
+	day2 := all.Availabilities[r][1] == "TRUE"
+	day3 := all.Availabilities[r][2] == "TRUE"
+	day4 := all.Availabilities[r][3] == "TRUE"
+
+	res := &EmployeeAvailability{
+		Day1:      EmployeeAvailabilityDay{IsAvailable: day1, Date: all.Dates[0].(string)},
+		Day2:      EmployeeAvailabilityDay{IsAvailable: day2, Date: all.Dates[1].(string)},
+		Day3:      EmployeeAvailabilityDay{IsAvailable: day3, Date: all.Dates[2].(string)},
+		Day4:      EmployeeAvailabilityDay{IsAvailable: day4, Date: all.Dates[3].(string)},
+		CanUpdate: all.CanUpdate,
+	}
+	log.Printf("[INFO] Found availability for %s: %v", employeeId, res)
+	return res, nil
 }

--- a/src/GoogleSheets/packages/availability/handlers/GetAvailability_test.go
+++ b/src/GoogleSheets/packages/availability/handlers/GetAvailability_test.go
@@ -2,8 +2,6 @@ package Availability
 
 import (
 	"GoogleSheets/packages/common/Constants/SharedConstants"
-	"io"
-	"log"
 	"reflect"
 	"testing"
 )
@@ -30,7 +28,6 @@ func (m *mockSheet) Update(row int, new *EmployeeAvailability) error {
 }
 
 func TestGet(t *testing.T) {
-	log.SetOutput(io.Discard)
 	s := &mockSheet{}
 	type Input struct {
 		id    string

--- a/src/GoogleSheets/packages/availability/handlers/GetAvailability_test.go
+++ b/src/GoogleSheets/packages/availability/handlers/GetAvailability_test.go
@@ -1,0 +1,129 @@
+package Availability
+
+import (
+	"GoogleSheets/packages/common/Constants/SharedConstants"
+	"io"
+	"log"
+	"reflect"
+	"testing"
+)
+
+type mockSheet struct{}
+
+func (m *mockSheet) Get() (*AllAvailability, error) {
+	return &AllAvailability{
+		EmployeeIds: [][]interface{}{
+			{"1"},
+			{"2"},
+		},
+		Availabilities: [][]interface{}{
+			{"FALSE", "FALSE", "FALSE", "FALSE"},
+			{"TRUE", "TRUE", "FALSE", "FALSE"},
+		},
+		Dates:     []interface{}{"d1", "d2", "d3", "d4"},
+		CanUpdate: true,
+	}, nil
+}
+
+func (m *mockSheet) Update(row int, new *EmployeeAvailability) error {
+	return nil
+}
+
+func TestGet(t *testing.T) {
+	log.SetOutput(io.Discard)
+	s := &mockSheet{}
+	type Input struct {
+		id    string
+		sheet availabilitySheet
+	}
+
+	tests := []struct {
+		name        string
+		input       Input
+		expected    EmployeeAvailability
+		shouldErr   bool
+		expectedErr error
+	}{
+		{
+			name: "should find employee 1",
+			input: Input{
+				id:    "1",
+				sheet: s,
+			},
+			expected: EmployeeAvailability{
+				Day1: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d1",
+				},
+				Day2: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d2",
+				},
+				Day3: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d3",
+				},
+				Day4: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d4",
+				},
+				CanUpdate: true,
+			},
+		},
+		{
+			name: "should find employee 2",
+			input: Input{
+				id:    "2",
+				sheet: s,
+			},
+			expected: EmployeeAvailability{
+				Day1: EmployeeAvailabilityDay{
+					IsAvailable: true,
+					Date:        "d1",
+				},
+				Day2: EmployeeAvailabilityDay{
+					IsAvailable: true,
+					Date:        "d2",
+				},
+				Day3: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d3",
+				},
+				Day4: EmployeeAvailabilityDay{
+					IsAvailable: false,
+					Date:        "d4",
+				},
+				CanUpdate: true,
+			},
+		},
+		{
+			name: "error finding employee 3",
+			input: Input{
+				id:    "3",
+				sheet: s,
+			},
+			shouldErr:   true,
+			expectedErr: SharedConstants.ErrEmployeeNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.shouldErr {
+				res, err := doGet(test.input.id, test.input.sheet)
+				if err != nil {
+					t.Errorf("failed to find employee %s availability", test.input.id)
+				}
+
+				if !reflect.DeepEqual(*res, test.expected) {
+					t.Errorf("expected and actual availabilities differ.\nactual: %v\nexpected: %v", res, test.expected)
+				}
+			} else {
+				_, err := doGet(test.input.id, test.input.sheet)
+				if err != test.expectedErr {
+					t.Errorf("expected and actual errors differ.\nactual: %s\nexpected: %s", err, test.expectedErr)
+				}
+			}
+		})
+	}
+}

--- a/src/GoogleSheets/packages/availability/handlers/UpdateAvailability.go
+++ b/src/GoogleSheets/packages/availability/handlers/UpdateAvailability.go
@@ -1,7 +1,6 @@
 package Availability
 
 import (
-	"fmt"
 	"log"
 )
 
@@ -27,7 +26,7 @@ func doUpdate(employeeId string, new *EmployeeAvailability, sheet availabilitySh
 	}
 
 	if !all.CanUpdate {
-		return fmt.Errorf(UPDATE_AVAILABILITY_DISABLED_ERROR)
+		return ErrNoUpdating
 	}
 
 	row, err := findRowOfEmployee(all.EmployeeIds, employeeId)

--- a/src/GoogleSheets/packages/availability/handlers/UpdateAvailability.go
+++ b/src/GoogleSheets/packages/availability/handlers/UpdateAvailability.go
@@ -1,6 +1,7 @@
 package Availability
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -10,11 +11,29 @@ func Update(employeeId string, newAvailability *EmployeeAvailability) error {
 		return err
 	}
 
-	err = sheet.Update(employeeId, newAvailability)
+	err = doUpdate(employeeId, newAvailability, sheet)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[INFO] Availability updated for %s: %v", employeeId, newAvailability)
 	return nil
+}
+
+func doUpdate(employeeId string, new *EmployeeAvailability, sheet availabilitySheet) error {
+	all, err := sheet.Get()
+	if err != nil {
+		return err
+	}
+
+	if !all.CanUpdate {
+		return fmt.Errorf(UPDATE_AVAILABILITY_DISABLED_ERROR)
+	}
+
+	row, err := findRowOfEmployee(all.EmployeeIds, employeeId)
+	if err != nil {
+		return err
+	}
+
+	return sheet.Update(row, new)
 }

--- a/src/GoogleSheets/packages/availability/handlers/UpdateAvailability_test.go
+++ b/src/GoogleSheets/packages/availability/handlers/UpdateAvailability_test.go
@@ -1,0 +1,64 @@
+package Availability
+
+import (
+	"GoogleSheets/packages/common/Constants/SharedConstants"
+	"testing"
+)
+
+type mockSheetNoUpdate struct{}
+
+func (m *mockSheetNoUpdate) Get() (*AllAvailability, error) {
+	return &AllAvailability{CanUpdate: false}, nil
+}
+func (m *mockSheetNoUpdate) Update(row int, new *EmployeeAvailability) error {
+	return nil
+}
+
+func TestUpdate(t *testing.T) {
+	s := &mockSheet{}
+	noUpdateSheet := &mockSheetNoUpdate{}
+	type Input struct {
+		id    string
+		new   *EmployeeAvailability
+		sheet availabilitySheet
+	}
+
+	tests := []struct {
+		name     string
+		input    Input
+		expected error
+	}{
+		{
+			name: "prevents update",
+			input: Input{
+				sheet: noUpdateSheet,
+			},
+			expected: ErrNoUpdating,
+		},
+		{
+			name: "employee not found",
+			input: Input{
+				id:    "3",
+				sheet: s,
+			},
+			expected: SharedConstants.ErrEmployeeNotFound,
+		},
+		{
+			name: "success",
+			input: Input{
+				id:    "1",
+				sheet: s,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := doUpdate(test.input.id, test.input.new, test.input.sheet)
+			if err != test.expected {
+				t.Errorf("expected and actual errors differ.\nactual: %s\nexpected: %s", err, test.expected)
+			}
+		})
+	}
+}

--- a/src/GoogleSheets/packages/availability/main.go
+++ b/src/GoogleSheets/packages/availability/main.go
@@ -70,10 +70,10 @@ func HandleRequest(ctx context.Context, event events.APIGatewayProxyRequest) (ev
 			log.Printf("[ERROR] Failed to update availability for %s: %s", employeeInfo.GetEmployeeId(), err.Error())
 			var statusCode int
 
-			switch err.Error() {
-			case Availability.UPDATE_AVAILABILITY_DISABLED_ERROR:
+			switch err {
+			case Availability.ErrNoUpdating:
 				statusCode = 403
-			case SharedConstants.ErrEmployeeNotFound.Error():
+			case SharedConstants.ErrEmployeeNotFound:
 				statusCode = 404
 			default:
 				statusCode = 500

--- a/src/GoogleSheets/packages/availability/main.go
+++ b/src/GoogleSheets/packages/availability/main.go
@@ -42,7 +42,7 @@ func HandleRequest(ctx context.Context, event events.APIGatewayProxyRequest) (ev
 		if err != nil {
 			log.Printf("[ERROR] Failed to get availability for %s: %s", employeeInfo.GetEmployeeId(), err.Error())
 			statusCode := 500
-			if err.Error() == SharedConstants.EMPLOYEE_NOT_FOUND_ERROR {
+			if err == SharedConstants.ErrEmployeeNotFound {
 				statusCode = 404
 			}
 			return events.APIGatewayProxyResponse{
@@ -73,7 +73,7 @@ func HandleRequest(ctx context.Context, event events.APIGatewayProxyRequest) (ev
 			switch err.Error() {
 			case Availability.UPDATE_AVAILABILITY_DISABLED_ERROR:
 				statusCode = 403
-			case SharedConstants.EMPLOYEE_NOT_FOUND_ERROR:
+			case SharedConstants.ErrEmployeeNotFound.Error():
 				statusCode = 404
 			default:
 				statusCode = 500

--- a/src/GoogleSheets/packages/common/Constants/SharedConstants/main.go
+++ b/src/GoogleSheets/packages/common/Constants/SharedConstants/main.go
@@ -10,13 +10,13 @@ type ErrorMessages string
 
 const (
 	NUM_OF_DATES              = 4
-	EMPLOYEE_NOT_FOUND_ERROR  = "employee not found"
 	INCLUDE_AUTH_HEADER_ERROR = "Please include Authorization header in request."
 	NOT_VALID_REQUEST_ERROR   = "Not a valid request"
 	INCLUDE_EMAIL_ERROR       = "Please include employee email in request."
 )
 
 var (
+	ErrEmployeeNotFound       = errors.New("employee not found")
 	ErrNotABearerToken        = errors.New("please provide a bearer token")
 	ErrInvalidIdToken         = errors.New("invalid idToken")
 	ErrNoEmployeeIdInToken    = errors.New("employeeId not found in idToken")


### PR DESCRIPTION
## Summary
The way the backend is implemented doesn't really allow for good testing practices (woops). This is the first attempt at making the backend more testable so we can have more robust development.

### Refactoring Notes
- Old error checking compared 2 error messages together --> make error a constant and compare
- New `availabilitySheet` interface allows for mocking. It's only responsible for fetching data from Google Sheets API.
  - Don't really care about testing the google sheets api.
- The logic we want to test is in `do{Op}()` 