### PR TITLE
Fix Work History date sort order

### DIFF
--- a/src/frontend/src/components/Timesheet/TimesheetWidget.tsx
+++ b/src/frontend/src/components/Timesheet/TimesheetWidget.tsx
@@ -22,7 +22,11 @@ export const TimesheetWidget = (p: {
   const sortedShifts = useMemo(
     () =>
       [...p.timesheetData.shifts].sort((a, b) => {
-        const comparison = a.date.localeCompare(b.date);
+        // Compare the actual calendar dates, not the formatted strings.
+        // The API sends dates like "Sunday, May 31, 2026", so localeCompare
+        // would sort them alphabetically (by weekday/month name) instead of
+        // chronologically.
+        const comparison = new Date(a.date).getTime() - new Date(b.date).getTime();
         return sortOrder === "asc" ? comparison : -comparison;
       }),
     [p.timesheetData.shifts, sortOrder],

--- a/src/frontend/src/components/Timesheet/__tests__/TimesheetWidget.test.tsx
+++ b/src/frontend/src/components/Timesheet/__tests__/TimesheetWidget.test.tsx
@@ -7,10 +7,14 @@ vi.mock("@/components/common/ScreenSizeHelpers", () => ({
   useIsDesktopView: () => true,
 }));
 
+// Dates use the same human-formatted shape the API returns (e.g.
+// "Sunday, May 31, 2026"). The months are chosen so that alphabetical
+// string order (April < June < May) differs from chronological order,
+// which would catch the date-sorting bug.
 const timesheetData: TimesheetData = {
   shifts: [
     {
-      date: "2024-06-01",
+      date: "Friday, April 24, 2026",
       shiftTitle: "Morning",
       startTime: "08:00",
       endTime: "16:00",
@@ -19,7 +23,7 @@ const timesheetData: TimesheetData = {
       employeeName: "John Doe",
     },
     {
-      date: "2024-06-03",
+      date: "Saturday, June 20, 2026",
       shiftTitle: "Evening",
       startTime: "16:00",
       endTime: "22:00",
@@ -28,7 +32,7 @@ const timesheetData: TimesheetData = {
       employeeName: "John Doe",
     },
     {
-      date: "2024-06-02",
+      date: "Sunday, May 31, 2026",
       shiftTitle: "Afternoon",
       startTime: "12:00",
       endTime: "18:00",
@@ -58,7 +62,11 @@ describe("TimesheetWidget", () => {
   it("sorts shifts by date descending by default", () => {
     renderWidget();
 
-    expect(renderedShiftDates()).toEqual(["2024-06-03", "2024-06-02", "2024-06-01"]);
+    expect(renderedShiftDates()).toEqual([
+      "Saturday, June 20, 2026",
+      "Sunday, May 31, 2026",
+      "Friday, April 24, 2026",
+    ]);
     expect(screen.getByRole("button", { name: /sort: desc/i })).toBeVisible();
   });
 
@@ -67,11 +75,19 @@ describe("TimesheetWidget", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /sort: desc/i }));
 
-    expect(renderedShiftDates()).toEqual(["2024-06-01", "2024-06-02", "2024-06-03"]);
+    expect(renderedShiftDates()).toEqual([
+      "Friday, April 24, 2026",
+      "Sunday, May 31, 2026",
+      "Saturday, June 20, 2026",
+    ]);
     expect(screen.getByRole("button", { name: /sort: asc/i })).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: /sort: asc/i }));
 
-    expect(renderedShiftDates()).toEqual(["2024-06-03", "2024-06-02", "2024-06-01"]);
+    expect(renderedShiftDates()).toEqual([
+      "Saturday, June 20, 2026",
+      "Sunday, May 31, 2026",
+      "Friday, April 24, 2026",
+    ]);
   });
 });


### PR DESCRIPTION
## Issue
Work History sorted dates as plain text (`localeCompare`). Since the API sends dates pre-formatted like "Sunday, May 31, 2026", they were ordered alphabetically by weekday/month name instead of chronologically — wrong in both Asc and Desc.

## Fix
Compare parsed `Date` values instead of strings. Updated the test fixture to the real date format so it guards against this.

## Screenshots
<!-- before / after images here -->
Before
<img width="1978" height="1408" alt="image" src="https://github.com/user-attachments/assets/ead37501-bf44-46f2-b9e6-07eef29c1bff" />
After
<img width="918" height="640" alt="image" src="https://github.com/user-attachments/assets/39f947a7-25ef-4bc9-835b-8e4b5fc4c27d" />
